### PR TITLE
(feat): FORGE-2164-Migration to Ditto v5

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "bfe249afe73839a23d8b50f5c8fd603e3f173b633edc3f973902e8c3d175161b",
+  "originHash" : "1e0850f0d689da802f5db0434b724554ff06f8d0ecdeed68b8c9f7cc5bf838a1",
   "pins" : [
     {
       "identity" : "dittoswiftpackage",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getditto/DittoSwiftPackage",
       "state" : {
-        "revision" : "19e91a34cebdf0a00c7674af71460133528c46a1",
-        "version" : "4.12.3"
+        "revision" : "8ca33bcf6f3f41500b12ee624f752bfc4845eeed",
+        "version" : "5.0.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
             targets: ["DittoChatUI"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/getditto/DittoSwiftPackage", from: "4.12.2"),
+        .package(url: "https://github.com/getditto/DittoSwiftPackage", exact: "5.0.1"),
         .package(url: "https://github.com/vadymmarkov/Fakery", from: "5.1.0"),
         .package(url: "https://github.com/apple/swift-collections", from: "1.0.0"),
     ],

--- a/apps/ios/DittoChatDemo.xcodeproj/project.pbxproj
+++ b/apps/ios/DittoChatDemo.xcodeproj/project.pbxproj
@@ -153,7 +153,7 @@
 			mainGroup = 7873E5542E68F35E003DC9B2;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
-				7806EAF32F7B40A00058119F /* XCRemoteSwiftPackageReference "DittoChat" */,
+				7806EAF32F7B40A00058119F /* XCLocalSwiftPackageReference "DittoChatPackage" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 7873E55E2E68F35E003DC9B2 /* Products */;
@@ -427,16 +427,12 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCRemoteSwiftPackageReference section */
-		7806EAF32F7B40A00058119F /* XCRemoteSwiftPackageReference "DittoChat" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/getditto/DittoChat";
-			requirement = {
-				branch = "bugfix/chat-crashes-on-observation";
-				kind = branch;
-			};
+/* Begin XCLocalSwiftPackageReference section */
+		7806EAF32F7B40A00058119F /* XCLocalSwiftPackageReference "DittoChatPackage" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = "../..";
 		};
-/* End XCRemoteSwiftPackageReference section */
+/* End XCLocalSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
 		0750235E2E985C0100AF7194 /* DittoChatCore */ = {
@@ -449,12 +445,10 @@
 		};
 		7806EAF42F7B40A00058119F /* DittoChatCore */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 7806EAF32F7B40A00058119F /* XCRemoteSwiftPackageReference "DittoChat" */;
 			productName = DittoChatCore;
 		};
 		7806EAF62F7B40A00058119F /* DittoChatUI */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 7806EAF32F7B40A00058119F /* XCRemoteSwiftPackageReference "DittoChat" */;
 			productName = DittoChatUI;
 		};
 		7873E56C2E68F390003DC9B2 /* DittoChatCore */ = {

--- a/apps/ios/DittoChatDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/apps/ios/DittoChatDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,22 +1,13 @@
 {
-  "originHash" : "46b859b4f3b871f0739d5b4ee2be10ccf136be2912fff5ffce3e77a1af827074",
+  "originHash" : "b6d35f5c23195e3642e4868145060e00f1088ca65ae9c55361fa6c89e24f1dc6",
   "pins" : [
-    {
-      "identity" : "dittochat",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/getditto/DittoChat",
-      "state" : {
-        "branch" : "feature/FORGE-740-Chat-Notifications",
-        "revision" : "b5576be0a6b7b81516c215b0a8da038355923ad4"
-      }
-    },
     {
       "identity" : "dittoswiftpackage",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getditto/DittoSwiftPackage",
       "state" : {
-        "revision" : "61b203cffc6a85c1c0d0987d1833d62eca7c549c",
-        "version" : "4.14.3"
+        "revision" : "8ca33bcf6f3f41500b12ee624f752bfc4845eeed",
+        "version" : "5.0.1"
       }
     },
     {
@@ -33,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
       "state" : {
-        "revision" : "8d9834a6189db730f6264db7556a7ffb751e99ee",
-        "version" : "1.4.0"
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
       }
     }
   ],

--- a/apps/ios/DittoChatDemo/ContentViewModel.swift
+++ b/apps/ios/DittoChatDemo/ContentViewModel.swift
@@ -89,9 +89,8 @@ final class ContentViewModel: ObservableObject {
                 }
             }
 
-            // v4 defaulted to DQL_STRICT_MODE = true; v5 defaults to false. Set it explicitly
-            // before sync starts to preserve the data-modeling semantics the app was built on.
-            try await dittoInstance.store.execute(query: "ALTER SYSTEM SET DQL_STRICT_MODE = true")
+            // v5 defaults to DQL_STRICT_MODE = false; set it explicitly before sync starts.
+            try await dittoInstance.store.execute(query: "ALTER SYSTEM SET DQL_STRICT_MODE = false")
 
             try dittoInstance.sync.start()
 

--- a/apps/ios/DittoChatDemo/ContentViewModel.swift
+++ b/apps/ios/DittoChatDemo/ContentViewModel.swift
@@ -19,12 +19,12 @@ final class ContentViewModel: ObservableObject {
 
     init() {
         projectMetadata = ProjectMetadata()
-        setup()
+        Task { await setup() }
     }
 
-    private func setup() {
+    private func setup() async {
         do {
-            let dittoInstance = try dittoInstanceForProject(projectMetadata)
+            let dittoInstance = try await dittoInstanceForProject(projectMetadata)
             ditto = dittoInstance
 
             dittoChat = try DittoChat.builder()
@@ -49,7 +49,7 @@ final class ContentViewModel: ObservableObject {
         ).appendingPathComponent(projectId)
     }
 
-    private func dittoInstanceForProject(_ proj: ProjectMetadata) throws -> Ditto {
+    private func dittoInstanceForProject(_ proj: ProjectMetadata) async throws -> Ditto {
 
         let directory = try dittoDirectory(forId: proj.id)
 
@@ -57,19 +57,42 @@ final class ContentViewModel: ObservableObject {
             throw DittoError.unsupportedError(message: "Ditto Already Initialized")
         }
 
-        let dittoIdentity: DittoIdentity =
-            .onlinePlayground(appID: proj.appID,
-                              token: proj.token,
-                              enableDittoCloudSync: true,
-                              customAuthURL: URL(string: "https://" + proj.cloudUrl))
+        // v5 `.server(url:)` takes the HTTPS base URL of the Ditto Server; the SDK derives the
+        // WebSocket (wss) sync transport and the auth challenge endpoint from it internally.
+        guard let serverURL = URL(string: "https://" + proj.cloudUrl) else {
+            throw DittoError.unsupportedError(message: "Invalid cloud URL: \(proj.cloudUrl)")
+        }
 
-        let dittoInstance = Ditto(identity: dittoIdentity, persistenceDirectory: directory)
-
-        dittoInstance.transportConfig.connect.webSocketURLs = ["wss://" + proj.cloudUrl]
+        // v5: DittoIdentity / transportConfig / disableSyncWithV3 are removed. The app ID is the
+        // databaseID, the Big Peer connection is expressed via `.server(url:)`, and authentication
+        // moves to `auth.login(token:provider:)` after the store is opened.
+        let config = DittoConfig(
+            databaseID: proj.appID,
+            connect: .server(url: serverURL),
+            persistenceDirectory: directory
+        )
 
         do {
-            try dittoInstance.disableSyncWithV3()
+            let dittoInstance = try await Ditto.open(config: config)
+
             DittoLogger.minimumLogLevel = .debug
+
+            // v5: authentication moves out of the identity and onto an expiration handler.
+            // The handler fires once for the initial login (timeUntilExpiration == 0) and again
+            // before the session token expires, so it covers both initial auth and refresh.
+            let token = proj.token
+            dittoInstance.auth?.expirationHandler = { ditto, _ in
+                ditto.auth?.login(token: token, provider: .development) { _, error in
+                    if let error {
+                        print("Ditto auth login error: \(error)")
+                    }
+                }
+            }
+
+            // v4 defaulted to DQL_STRICT_MODE = true; v5 defaults to false. Set it explicitly
+            // before sync starts to preserve the data-modeling semantics the app was built on.
+            try await dittoInstance.store.execute(query: "ALTER SYSTEM SET DQL_STRICT_MODE = true")
+
             try dittoInstance.sync.start()
 
             return dittoInstance

--- a/sdks/kotlin/build.gradle.kts
+++ b/sdks/kotlin/build.gradle.kts
@@ -93,7 +93,7 @@ dependencies {
     debugImplementation(libs.androidx.ui.tooling)
 }
 
-val publishVersion = "1.0.2"
+val publishVersion = "1.0.3"
 
 mavenPublishing {
     // Configure which Sonatype instance to use

--- a/sdks/swift/Sources/DittoChatCore/Data/DittoDataInterface.swift
+++ b/sdks/swift/Sources/DittoChatCore/Data/DittoDataInterface.swift
@@ -31,7 +31,7 @@ protocol DittoDataInterface {
     func messagesPublisher(for room: Room, retentionDays: Int?) -> AnyPublisher<[Message], Never>
     func messagePublisher(for msgId: String, in collectionId: String) -> AnyPublisher<Message, Never>
     func attachmentPublisher(
-        for token: DittoAttachmentToken,
+        for token: [String: Any],
         in collectionId: String
     ) -> DittoStore.FetchAttachmentPublisher?
     func createUpdateMessage(document: [String: Any?])

--- a/sdks/swift/Sources/DittoChatCore/Data/DittoService.swift
+++ b/sdks/swift/Sources/DittoChatCore/Data/DittoService.swift
@@ -16,7 +16,7 @@ class DittoService: DittoDataInterface {
     @Published fileprivate private(set) var allPublicRooms: [Room] = []
     private var allPublicRoomsCancellable: AnyCancellable = AnyCancellable({})
     private var cancellables = Set<AnyCancellable>()
-    private var usersSubscription: DittoSubscription?
+    private var usersSubscription: DittoSyncSubscription?
 
     private var privateRoomSubscriptions = [String: DittoSyncSubscription]()
     private var privateRoomMessagesSubscriptions = [String: DittoSyncSubscription]()
@@ -36,7 +36,11 @@ class DittoService: DittoDataInterface {
         self.chatRetentionPolicy = chatRetentionPolicy
 
         if let ditto = ditto {
-            self.usersSubscription = ditto.store[usersCollection].findAll().subscribe()
+            do {
+                self.usersSubscription = try ditto.sync.registerSubscription(query: "SELECT * FROM `\(usersCollection)`")
+            } catch {
+                print("Error subscribing to users collection: \(error)")
+            }
         }
 
         createDefaultPublicRoom()
@@ -205,7 +209,7 @@ extension DittoService {
         }
 
         return ditto.store
-            .observePublisher(query: "SELECT * FROM COLLECTION `\(usersKey)` (`\(subscriptionsKey)` MAP, `\(mentionsKey)` MAP)", mapTo: ChatUser.self)
+            .observePublisher(query: "SELECT * FROM COLLECTION `\(usersKey)` (`\(subscriptionsKey)` MAP, `\(mentionsKey)` MAP) ORDER BY \(nameKey) ASC", mapTo: ChatUser.self)
             .catch { error in
                 assertionFailure("ERROR with \(#function)" + error.localizedDescription)
                 return Empty<[ChatUser], Never>()
@@ -477,7 +481,7 @@ extension DittoService {
    }
 
     func attachmentPublisher(
-        for token: DittoAttachmentToken,
+        for token: [String: Any],
         in collectionId: String
     ) -> DittoSwift.DittoStore.FetchAttachmentPublisher? {
         guard let ditto = ditto else { return nil }
@@ -681,7 +685,7 @@ extension DittoService {
 
 extension DittoService {
     var peerKeyString: String {
-        ditto?.presence.graph.localPeer.peerKeyString ?? ""
+        ditto?.presence.graph.localPeer.peerKey ?? ""
     }
 
     var sdkVersion: String {

--- a/sdks/swift/Sources/DittoChatCore/DittoChat.swift
+++ b/sdks/swift/Sources/DittoChatCore/DittoChat.swift
@@ -411,7 +411,7 @@ extension DittoChat {
     }
 
     func attachmentPublisher(
-        for token: DittoAttachmentToken,
+        for token: [String: Any],
         in collectionId: String
     ) -> DittoSwift.DittoStore.FetchAttachmentPublisher? {
         p2pStore.attachmentPublisher(for: token, in: collectionId)
@@ -425,7 +425,7 @@ extension DittoChat {
     public func fetchAttachment(
         token: [String : Any],
         deliverOn queue: DispatchQueue = .main,
-        onFetchEvent: @escaping (DittoAttachmentFetchEvent) -> Void
+        onFetchEvent: @escaping @Sendable (DittoAttachmentFetchEvent) -> Void
     ) throws -> DittoAttachmentFetcher? {
         try p2pStore.ditto?.store.fetchAttachment(token: token, deliverOn: queue, onFetchEvent: onFetchEvent)
     }

--- a/sdks/swift/Sources/DittoChatCore/Utilities/Publishers.swift
+++ b/sdks/swift/Sources/DittoChatCore/Utilities/Publishers.swift
@@ -23,7 +23,11 @@ extension DittoStore {
     func executePublisher<T: DittoDecodable>(query: String, arguments: Dictionary<String, Any?>? = [:], mapTo: T.Type) async -> [T] {
             do {
                 let result = try await self.execute(query: query, arguments: arguments ?? [:])
-                let items = result.items.compactMap { T(value: $0.value) }
+                let items = result.items.compactMap { item -> T? in
+                    let mapped = T(value: item.value)
+                    item.dematerialize() // v5: free native memory backing the result item
+                    return mapped
+                }
                 return items
             } catch {
                 return []
@@ -36,6 +40,7 @@ extension DittoStore {
             let result = try await self.execute(query: query, arguments: arguments ?? [:])
             guard let first = result.items.first else { return nil }
             let item = T(value: first.value)
+            first.dematerialize() // v5: free native memory backing the result item
             return item
         } catch {
             throw error
@@ -57,7 +62,11 @@ extension DittoStore {
 
         do {
             try self.registerObserver(query: query, arguments: arguments, deliverOn: queue) { result in
-                let items = result.items.compactMap { T(value: $0.value) }
+                let items = result.items.compactMap { item -> T? in
+                    let mapped = T(value: item.value)
+                    item.dematerialize() // v5: free native memory backing the result item
+                    return mapped
+                }
                 subject.send(items)
             }
         } catch {
@@ -75,6 +84,7 @@ extension DittoStore {
             try self.registerObserver(query: query, arguments: arguments, deliverOn: queue) { result in
                 guard let first = result.items.first else { return subject.send(nil) }
                 let item = T(value: first.value)
+                first.dematerialize() // v5: free native memory backing the result item
                 subject.send(item)
             }
         } catch {

--- a/sdks/swift/Sources/DittoChatUI/Screens/ChatScreen/ChatScreen.swift
+++ b/sdks/swift/Sources/DittoChatUI/Screens/ChatScreen/ChatScreen.swift
@@ -151,7 +151,7 @@ public struct ChatScreen: View {
         .padding(.trailing, 4)
         .frame(width: 56, height: 44)
         .buttonStyle(.borderless)
-        .onChange(of: viewModel.selectedItem) { newValue, _ in
+        .onChange(of: viewModel.selectedItem) { _, newValue in
             Task {
                 do {
                     let imageData = try await newValue?.loadTransferable(type: Data.self)

--- a/sdks/swift/Sources/DittoChatUI/Screens/ChatScreen/MessageBubbleVM.swift
+++ b/sdks/swift/Sources/DittoChatUI/Screens/ChatScreen/MessageBubbleVM.swift
@@ -116,8 +116,8 @@ class MessageBubbleVM: ObservableObject {
 public struct ImageAttachmentFetcher {
     public typealias CompletionRatio = CGFloat
     public typealias ImageMetadataTuple = (image: UIImage, metadata: [String: String])
-    public typealias ProgressHandler = (CompletionRatio) -> Void
-    public typealias CompletionHandler = (Result<ImageMetadataTuple, Error>) -> Void
+    public typealias ProgressHandler = @MainActor @Sendable (CompletionRatio) -> Void
+    public typealias CompletionHandler = @MainActor @Sendable (Result<ImageMetadataTuple, Error>) -> Void
 
     @MainActor public func fetch(with token: [String: Any]?,
                from collectionId: String,
@@ -128,30 +128,45 @@ public struct ImageAttachmentFetcher {
 
         // Fetch the thumbnail data from Ditto, calling the progress handler to
         // report the operation's ongoing progress.
-        let _ = try? dittoChat.fetchAttachment(token: token) { event in
-            switch event {
-            case .progress(let downloadedBytes, let totalBytes):
-                let percent = Double(downloadedBytes) / Double(totalBytes)
-                onProgress(percent)
+        //
+        // The callback is @Sendable in v5 and Ditto may deliver it on an internal utility-qos
+        // thread even though `deliverOn: .main` is the default (see Publishers.swift). We must NOT
+        // assume main-actor isolation on entry — doing so crashes ("incorrect actor executor
+        // assumption"). Instead we explicitly hop to the main queue (which guarantees the main
+        // thread) and only then bridge to the main actor to call the @MainActor handlers.
+        do {
+        let _ = try dittoChat.fetchAttachment(token: token) { event in
+            DispatchQueue.main.async {
+                MainActor.assumeIsolated {
+                    switch event {
+                case .progress(let downloadedBytes, let totalBytes):
+                    let percent = Double(downloadedBytes) / Double(totalBytes)
+                    onProgress(percent)
 
-            case .completed(let attachment):
-                do {
-                    let data = try attachment.data()
-                    if let uiImage = UIImage(data: data) {
-                        onComplete(.success( (image: uiImage, metadata: attachment.metadata) ))
+                case .completed(let attachment):
+                    do {
+                        let data = try attachment.data()
+                        if let uiImage = UIImage(data: data) {
+                            onComplete(.success( (image: uiImage, metadata: attachment.metadata) ))
+                        }
+                    } catch {
+                        print("\(#function) ERROR: \(error.localizedDescription)")
+                        onComplete(.failure(error))
                     }
-                } catch {
-                    print("\(#function) ERROR: \(error.localizedDescription)")
-                    onComplete(.failure(error))
+
+                case .deleted:
+                    onComplete(.failure(AttachmentError.deleted))
+
+                    @unknown default:
+                        print("ImageFetcher.fetch(): default case - unknown condition")
+                        onComplete(.failure(AttachmentError.unknown("Unkown attachment error")))
+                    }
                 }
-
-            case .deleted:
-                onComplete(.failure(AttachmentError.deleted))
-
-            @unknown default:
-                print("ImageFetcher.fetch(): default case - unknown condition")
-                onComplete(.failure(AttachmentError.unknown("Unkown attachment error")))
             }
+        }
+        } catch {
+            print("ImageAttachmentFetcher.fetch: failed to start attachment fetch: \(error)")
+            onComplete(.failure(error))
         }
     }
 }

--- a/sdks/swift/Sources/DittoChatUI/Screens/ChatScreen/MessageBubbleVM.swift
+++ b/sdks/swift/Sources/DittoChatUI/Screens/ChatScreen/MessageBubbleVM.swift
@@ -51,54 +51,87 @@ class MessageBubbleVM: ObservableObject {
             : message.thumbnailImageToken
         else { return }
 
-        ImageAttachmentFetcher().fetch(
-            with: token,
-            from: messagesId,
-            dittoChat: dittoChat,
-            onProgress: { [weak self] (ratio: ImageAttachmentFetcher.CompletionRatio) in
-                switch type {
-                case .thumbnailImage:
-                    self?.thumbnailProgress = ratio
-                case .largeImage:
-                    self?.fetchProgress = ratio
-                }
-            },
-            onComplete: { [weak self] (result: Result<ImageAttachmentFetcher.ImageMetadataTuple, any Error>) in
-                guard let self else { return }
+        // Bridge Ditto's callback-based fetch into an AsyncStream. The fetch is started here on
+        // the main actor; its @Sendable callback — which Ditto may invoke on a background thread —
+        // performs the blocking `data()` read off-main and yields Sendable updates. We consume
+        // them back on the main actor via `for await`, so UI state is updated with no manual
+        // thread hopping or `assumeIsolated` assertions.
+        let (updates, continuation) = AsyncStream.makeStream(of: AttachmentUpdate.self)
 
-                switch result {
-                case .success(let tuple):
-                    let uiImage = tuple.0
-                    let metadata = tuple.1
-
-                    switch type {
-                    case .thumbnailImage:
-                        self.thumbnailImage = Image(uiImage: uiImage)
-
-                    case .largeImage:
-                        let fname = metadata[filenameKey] ?? unnamedLargeImageFileKey
-
-                        if let tmp = try? TemporaryFile(creatingTempDirectoryForFilename: fname) {
-                            self.tmpStorage = tmp
-
-                            if let _ = try? uiImage.jpegData(compressionQuality: 1.0)?.write(to: tmp.fileURL) {
-                                self.fileURL = tmp.fileURL
-                            } else {
-                                print("ImageAttachmentFetcher.onComplete: Error writing JPG attachment data to file at path: \(tmp.fileURL.path) --> Return")
-                            }
-                        } else {
-                            print("ImageAttachmentFetcher.onComplete.success ERROR creating tmpStorage")
-                        }
+        let fetcher: DittoAttachmentFetcher?
+        do {
+            fetcher = try dittoChat.fetchAttachment(token: token) { event in
+                switch event {
+                case .progress(let downloadedBytes, let totalBytes):
+                    let ratio = totalBytes > 0 ? Double(downloadedBytes) / Double(totalBytes) : 0
+                    continuation.yield(.progress(ratio))
+                case .completed(let attachment):
+                    if let data = try? attachment.data() {
+                        continuation.yield(.image(data, metadata: attachment.metadata))
+                    } else {
+                        continuation.yield(.failed)
                     }
-
-                case .failure:
-                    print("MessageBubbleVM.ImageAttachmentFetcher.failure: UNKNOWN Thumbnail image Error")
-                    self.thumbnailImage = Image(uiImage: UIImage(systemName: messageImageFailKey)!)
-
-                    // do nothing for large image fetch
+                    continuation.finish()
+                case .deleted:
+                    continuation.yield(.failed)
+                    continuation.finish()
+                @unknown default:
+                    continuation.yield(.failed)
+                    continuation.finish()
                 }
             }
-        )
+        } catch {
+            print("MessageBubbleVM.fetchAttachment: failed to start fetch: \(error)")
+            fetcher = nil
+            continuation.yield(.failed)
+            continuation.finish()
+        }
+
+        // Keep the fetcher alive for the lifetime of the stream.
+        continuation.onTermination = { @Sendable _ in _ = fetcher }
+
+        for await update in updates {
+            switch update {
+            case .progress(let ratio):
+                switch type {
+                case .thumbnailImage: thumbnailProgress = ratio
+                case .largeImage: fetchProgress = ratio
+                }
+
+            case .image(let data, let metadata):
+                guard let uiImage = UIImage(data: data) else {
+                    if type == .thumbnailImage { setThumbnailFailImage() }
+                    continue
+                }
+                switch type {
+                case .thumbnailImage:
+                    thumbnailImage = Image(uiImage: uiImage)
+                case .largeImage:
+                    saveLargeImage(uiImage, metadata: metadata)
+                }
+
+            case .failed:
+                if type == .thumbnailImage { setThumbnailFailImage() }
+            }
+        }
+    }
+
+    private func saveLargeImage(_ uiImage: UIImage, metadata: [String: String]) {
+        let fname = metadata[filenameKey] ?? unnamedLargeImageFileKey
+        guard let tmp = try? TemporaryFile(creatingTempDirectoryForFilename: fname) else {
+            print("MessageBubbleVM.saveLargeImage: ERROR creating tmpStorage")
+            return
+        }
+        tmpStorage = tmp
+        if (try? uiImage.jpegData(compressionQuality: 1.0)?.write(to: tmp.fileURL)) != nil {
+            fileURL = tmp.fileURL
+        } else {
+            print("MessageBubbleVM.saveLargeImage: Error writing JPG attachment data to \(tmp.fileURL.path)")
+        }
+    }
+
+    private func setThumbnailFailImage() {
+        thumbnailImage = Image(uiImage: UIImage(systemName: messageImageFailKey)!)
     }
 
     func closeTemporaryStorage() {
@@ -112,61 +145,10 @@ class MessageBubbleVM: ObservableObject {
     }
 }
 
-@MainActor
-public struct ImageAttachmentFetcher {
-    public typealias CompletionRatio = CGFloat
-    public typealias ImageMetadataTuple = (image: UIImage, metadata: [String: String])
-    public typealias ProgressHandler = @MainActor @Sendable (CompletionRatio) -> Void
-    public typealias CompletionHandler = @MainActor @Sendable (Result<ImageMetadataTuple, Error>) -> Void
-
-    @MainActor public func fetch(with token: [String: Any]?,
-               from collectionId: String,
-                dittoChat: DittoChat,
-               onProgress: @escaping ProgressHandler,
-               onComplete: @escaping CompletionHandler) {
-        guard let token = token else { return }
-
-        // Fetch the thumbnail data from Ditto, calling the progress handler to
-        // report the operation's ongoing progress.
-        //
-        // The callback is @Sendable in v5 and Ditto may deliver it on an internal utility-qos
-        // thread even though `deliverOn: .main` is the default (see Publishers.swift). We must NOT
-        // assume main-actor isolation on entry — doing so crashes ("incorrect actor executor
-        // assumption"). Instead we explicitly hop to the main queue (which guarantees the main
-        // thread) and only then bridge to the main actor to call the @MainActor handlers.
-        do {
-        let _ = try dittoChat.fetchAttachment(token: token) { event in
-            DispatchQueue.main.async {
-                MainActor.assumeIsolated {
-                    switch event {
-                case .progress(let downloadedBytes, let totalBytes):
-                    let percent = Double(downloadedBytes) / Double(totalBytes)
-                    onProgress(percent)
-
-                case .completed(let attachment):
-                    do {
-                        let data = try attachment.data()
-                        if let uiImage = UIImage(data: data) {
-                            onComplete(.success( (image: uiImage, metadata: attachment.metadata) ))
-                        }
-                    } catch {
-                        print("\(#function) ERROR: \(error.localizedDescription)")
-                        onComplete(.failure(error))
-                    }
-
-                case .deleted:
-                    onComplete(.failure(AttachmentError.deleted))
-
-                    @unknown default:
-                        print("ImageFetcher.fetch(): default case - unknown condition")
-                        onComplete(.failure(AttachmentError.unknown("Unkown attachment error")))
-                    }
-                }
-            }
-        }
-        } catch {
-            print("ImageAttachmentFetcher.fetch: failed to start attachment fetch: \(error)")
-            onComplete(.failure(error))
-        }
-    }
+/// Sendable updates bridged from Ditto's attachment-fetch callback (which may run off the main
+/// thread) to the main-actor consumer in `MessageBubbleVM.fetchAttachment(type:)`.
+private enum AttachmentUpdate: Sendable {
+    case progress(Double)
+    case image(Data, metadata: [String: String])
+    case failed
 }


### PR DESCRIPTION
## Summary
Migrates the DittoChat Swift package and demo app from Ditto SDK **v4.12 → v5.0.1**.

The package was already DQL-first, so the API surface changes are small; the larger pieces are the dependency/init changes and re-wiring the demo app to build against the local package.

## Package (DittoChatCore / DittoChatUI)
- `Package.swift` pinned to `DittoSwift` **exact 5.0.1**. tvOS is **retained** — v5 still ships a tvOS slice despite the docs claiming otherwise (verified against the resolved xcframework).
- Replaced the last legacy query-builder call (`store[...].findAll().subscribe()`) with a DQL `sync.registerSubscription`; `DittoSubscription` → `DittoSyncSubscription`.
- `DittoAttachmentToken` (removed in v5) → `[String: Any]` in `attachmentPublisher`.
- Presence `peerKeyString` → `peerKey`.
- `fetchAttachment` event handler is now `@Sendable`; bridge it back to the main actor via an explicit main-queue hop (Ditto can deliver off-main despite `deliverOn: .main`) and stop swallowing the start error with `try?`.
- Call `dematerialize()` on result items in the observe/execute mappers (v5 native-memory management).
- `allUsersPublisher`: add `ORDER BY` for stable observer ordering.

## Demo app
- `ContentViewModel`: `DittoIdentity` / `transportConfig` / `disableSyncWithV3` → `DittoConfig` + `Ditto.open`; auth via `expirationHandler`; `.server(url:)` uses the `https` base; set `DQL_STRICT_MODE = true` before sync to preserve v4 data-merge semantics.
- Xcode project now references the **local** Swift package instead of the remote v4 branch, so it builds against this migration.

## Bug fix (surfaced by the local-package switch)
- `ChatScreen` photo-picker `onChange` used the `(oldValue, newValue)` parameters in the wrong order, so the selected image was never sent. Fixed.

## Verification
- `DittoChatCore`, `DittoChatUI`, and the demo app all build clean for iOS simulator against 5.0.1; tests compile clean.
- Ran the demo: confirmed `sdk.version=5.0.1`, rooms render, and image send/display works end-to-end.

## Notes for reviewers
- Cross-checked against Ditto's official Swift v4→v5 migration guide.
