### PR TITLE
chore(ci): make OWASP scheduled and consolidate PR comments

### DIFF
--- a/.github/workflows/lint-and-build-check.yml
+++ b/.github/workflows/lint-and-build-check.yml
@@ -4,10 +4,12 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
-  pull-requests: write
-  issues: write
 
 jobs:
   release:

--- a/.github/workflows/owasp-check.yml
+++ b/.github/workflows/owasp-check.yml
@@ -1,19 +1,14 @@
 name: OWASP Dependency Check
 
 on:
-  pull_request:
-    branches: [main]
-    paths:
-      - 'sdks/js/**'
-      - 'package.json'
-      - 'package-lock.json'
-      - '.github/workflows/owasp-check.yml'
+  schedule:
+    # Every Monday at 06:00 UTC
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
 
 permissions:
   contents: read
-  pull-requests: write
   issues: write
-  security-events: write
 
 jobs:
   dependency-check:
@@ -60,12 +55,12 @@ jobs:
           EOF
 
       - name: Run OWASP Dependency-Check
-        uses: dependency-check/Dependency-Check_Action@main
+        uses: dependency-check/Dependency-Check_Action@1.1.0
         id: depcheck
         with:
           project: "${{ matrix.workspace }}"
           path: "${{ matrix.path }}"
-          format: "ALL"
+          format: "HTML,JSON"
           args: >
             -s "${{ matrix.path }}/package.json"
             -s "package-lock.json"
@@ -77,7 +72,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: dependency-check-report-${{ hashFiles(format('{0}/package.json', matrix.path)) }}
+          name: dependency-check-report-${{ matrix.path == 'sdks/js/ditto-chat-core' && 'core' || 'ui' }}
           path: reports/
           retention-days: 15
 
@@ -96,120 +91,86 @@ jobs:
             LOW=$(jq '[.dependencies[].vulnerabilities[]? | select(.severity == "LOW" or .severity == "low")] | length' "$REPORT_FILE")
             TOTAL=$(jq '[.dependencies[].vulnerabilities[]?] | length' "$REPORT_FILE")
 
-            echo "critical=$CRITICAL" >> $GITHUB_OUTPUT
-            echo "high=$HIGH" >> $GITHUB_OUTPUT
-            echo "medium=$MEDIUM" >> $GITHUB_OUTPUT
-            echo "low=$LOW" >> $GITHUB_OUTPUT
-            echo "total=$TOTAL" >> $GITHUB_OUTPUT
+            {
+              echo "critical=$CRITICAL"
+              echo "high=$HIGH"
+              echo "medium=$MEDIUM"
+              echo "low=$LOW"
+              echo "total=$TOTAL"
+              echo "workspace=$WORKSPACE"
+            } >> "$GITHUB_OUTPUT"
 
-            # Extract detailed vulnerabilities
-            echo "VULNERABILITIES<<EOF" >> $GITHUB_OUTPUT
-            jq -r '.dependencies[] | select(.vulnerabilities) | .fileName as $file | .vulnerabilities[] | "- **\(.name)** (\(.severity)) in `\($file)`\n  - Description: \(.description // "N/A" | gsub("[`\\n\\r\"$]"; " "))\n  - CVSS: \(.cvssv3.baseScore // .cvssv2.score // "N/A")\n"' "$REPORT_FILE" | head -n 50 >> $GITHUB_OUTPUT
-            echo "EOF" >> $GITHUB_OUTPUT
+            # Write markdown summary for issue body
+            {
+              echo "## OWASP Dependency Check — \`$WORKSPACE\`"
+              echo ""
+              echo "| Severity | Count |"
+              echo "|----------|------:|"
+              echo "| Critical | $CRITICAL |"
+              echo "| High     | $HIGH |"
+              echo "| Medium   | $MEDIUM |"
+              echo "| Low      | $LOW |"
+              echo "| **Total**| **$TOTAL** |"
+              echo ""
+              if [ "$TOTAL" -gt 0 ]; then
+                echo "### Vulnerability Details"
+                echo ""
+                jq -r '.dependencies[] | select(.vulnerabilities) | .fileName as $file | .vulnerabilities[] | "- **\(.name)** (\(.severity)) in `\($file)`\n  CVSS: \(.cvssv3.baseScore // .cvssv2.score // "N/A")"' "$REPORT_FILE" | head -n 60
+              fi
+              echo ""
+              echo "[View full artifact](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+            } > vuln-summary-${{ matrix.path == 'sdks/js/ditto-chat-core' && 'core' || 'ui' }}.md
           else
-            echo "critical=0" >> $GITHUB_OUTPUT
-            echo "high=0" >> $GITHUB_OUTPUT
-            echo "medium=0" >> $GITHUB_OUTPUT
-            echo "low=0" >> $GITHUB_OUTPUT
-            echo "total=0" >> $GITHUB_OUTPUT
-            echo "VULNERABILITIES=No vulnerabilities found" >> $GITHUB_OUTPUT
+            {
+              echo "critical=0"
+              echo "high=0"
+              echo "medium=0"
+              echo "low=0"
+              echo "total=0"
+              echo "workspace=$WORKSPACE"
+            } >> "$GITHUB_OUTPUT"
+            echo "No report generated for $WORKSPACE." > vuln-summary-${{ matrix.path == 'sdks/js/ditto-chat-core' && 'core' || 'ui' }}.md
           fi
 
-      - name: Comment PR with Detailed Results
+      - name: Upload vulnerability summary
         if: always()
-        uses: actions/github-script@v7
-        env:
-          VULN_DATA: ${{ steps.summary.outputs.VULNERABILITIES }}
+        uses: actions/upload-artifact@v4
         with:
-          script: |
-            const workspace = '${{ matrix.workspace }}';
-            const critical = '${{ steps.summary.outputs.critical }}';
-            const high = '${{ steps.summary.outputs.high }}';
-            const medium = '${{ steps.summary.outputs.medium }}';
-            const low = '${{ steps.summary.outputs.low }}';
-            const total = '${{ steps.summary.outputs.total }}';
-            const vulnerabilities = process.env.VULN_DATA;
+          name: vuln-summary-${{ matrix.path == 'sdks/js/ditto-chat-core' && 'core' || 'ui' }}
+          path: vuln-summary-${{ matrix.path == 'sdks/js/ditto-chat-core' && 'core' || 'ui' }}.md
+          retention-days: 7
 
-            // Determine status emoji and message
-            let statusEmoji = '✅';
-            let statusMessage = 'No vulnerabilities found';
+  open-issue-on-failure:
+    runs-on: ubuntu-latest
+    needs: [dependency-check]
+    if: failure()
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Download vulnerability summaries
+        uses: actions/download-artifact@v4
+        with:
+          pattern: vuln-summary-*
+          merge-multiple: true
 
-            if (parseInt(critical) > 0 || parseInt(high) > 0) {
-              statusEmoji = '🚨';
-              statusMessage = 'Critical or High severity vulnerabilities detected!';
-            } else if (parseInt(medium) > 0) {
-              statusEmoji = '⚠️';
-              statusMessage = 'Medium severity vulnerabilities detected';
-            } else if (parseInt(low) > 0) {
-              statusEmoji = 'ℹ️';
-              statusMessage = 'Low severity vulnerabilities detected';
-            }
+      - name: Build combined issue body
+        run: |
+          {
+            echo "# OWASP Dependency Check Failures"
+            echo ""
+            echo "The scheduled OWASP dependency check detected vulnerabilities."
+            echo "Run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            echo ""
+            for f in vuln-summary-*.md; do
+              [ -f "$f" ] && cat "$f" && echo ""
+            done
+          } > issue-body.md
 
-            const body = `## ${statusEmoji} OWASP Dependency Check - \`${workspace}\`
-
-            ### ${statusMessage}
-
-            | Severity | Count |
-            |----------|------:|
-            | 🔴 Critical | **${critical}** |
-            | 🟠 High     | **${high}** |
-            | 🟡 Medium   | **${medium}** |
-            | 🔵 Low      | **${low}** |
-            | **Total**   | **${total}** |
-
-            ${parseInt(total) > 0 ? `
-            ### 📋 Vulnerability Details
-
-            ${vulnerabilities}
-
-            ${parseInt(total) > 50 ? '_Note: Showing first 50 vulnerabilities. Check the full report for complete details._' : ''}
-            ` : ''}
-
-            ---
-
-            📊 **[View Full HTML Report](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})**
-
-            <details>
-            <summary>ℹ️ How to fix vulnerabilities</summary>
-
-            1. Update vulnerable dependencies to patched versions
-            2. Run \`npm audit fix\` or \`npm audit fix --force\` in the root directory
-            3. Check for alternative packages if updates aren't available
-            4. Review and update your \`package.json\` and \`package-lock.json\`
-
-            </details>
-            `;
-
-            // Find existing comment
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-
-            const botComment = comments.find(comment =>
-              comment.user.type === 'Bot' &&
-              comment.body.includes(`OWASP Dependency Check - \`${workspace}\``)
-            );
-
-            // Update or create comment
-            if (botComment) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: botComment.id,
-                body: body
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body: body
-              });
-            }
-
-            // Fail the job if critical or high vulnerabilities found
-            if (parseInt(critical) > 0 || parseInt(high) > 0) {
-              core.setFailed(`Found ${critical} critical and ${high} high severity vulnerabilities in ${workspace}`);
-            }
+      - name: Create or update tracking issue
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: "OWASP Dependency Check failures"
+          content-filepath: issue-body.md
+          labels: security
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-cases.yml
+++ b/.github/workflows/test-cases.yml
@@ -4,10 +4,12 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
-  pull-requests: write
-  issues: write
 
 jobs:
   test-coverage:
@@ -22,8 +24,10 @@ jobs:
         include:
           - workspace: "@dittolive/ditto-chat-core"
             path: "sdks/js/ditto-chat-core"
+            short: "core"
           - workspace: "@dittolive/ditto-chat-ui"
             path: "sdks/js/ditto-chat-ui"
+            short: "ui"
       fail-fast: false
 
     steps:
@@ -44,21 +48,11 @@ jobs:
         run: npm run test:coverage -w ${{ matrix.workspace }}
         continue-on-error: false
 
-      - name: Generate coverage report
-        working-directory: ${{ matrix.path }}
-        run: |
-          # Generate coverage summary
-          if [ -f "coverage/coverage-summary.json" ]; then
-            echo "COVERAGE_SUMMARY<<EOF" >> $GITHUB_ENV
-            cat coverage/coverage-summary.json
-            echo "EOF" >> $GITHUB_ENV
-          fi
-
       - name: Upload coverage reports
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-report-${{ hashFiles(format('{0}/package.json', matrix.path)) }}
+          name: coverage-report-${{ matrix.short }}
           path: ${{ matrix.path }}/coverage/
           retention-days: 15
 
@@ -73,106 +67,20 @@ jobs:
             FUNCTIONS=$(jq -r '.total.functions.pct' coverage/coverage-summary.json)
             BRANCHES=$(jq -r '.total.branches.pct' coverage/coverage-summary.json)
 
-            echo "lines=$LINES" >> $GITHUB_OUTPUT
-            echo "statements=$STATEMENTS" >> $GITHUB_OUTPUT
-            echo "functions=$FUNCTIONS" >> $GITHUB_OUTPUT
-            echo "branches=$BRANCHES" >> $GITHUB_OUTPUT
-
+            {
+              echo "lines=$LINES"
+              echo "statements=$STATEMENTS"
+              echo "functions=$FUNCTIONS"
+              echo "branches=$BRANCHES"
+            } >> "$GITHUB_OUTPUT"
           else
-            echo "lines=0" >> $GITHUB_OUTPUT
-            echo "statements=0" >> $GITHUB_OUTPUT
-            echo "functions=0" >> $GITHUB_OUTPUT
-            echo "branches=0" >> $GITHUB_OUTPUT
+            {
+              echo "lines=0"
+              echo "statements=0"
+              echo "functions=0"
+              echo "branches=0"
+            } >> "$GITHUB_OUTPUT"
           fi
-
-      - name: Comment PR with coverage results
-        if: always()
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const workspace = '${{ matrix.workspace }}';
-            const lines = parseFloat('${{ steps.coverage.outputs.lines }}');
-            const statements = parseFloat('${{ steps.coverage.outputs.statements }}');
-            const functions = parseFloat('${{ steps.coverage.outputs.functions }}');
-            const branches = parseFloat('${{ steps.coverage.outputs.branches }}');
-
-            // Determine coverage status
-            const getCoverageEmoji = (pct) => {
-              if (pct >= 80) return '🟢';
-              if (pct >= 60) return '🟡';
-              if (pct >= 40) return '🟠';
-              return '🔴';
-            };
-
-            const getCoverageColor = (pct) => {
-              if (pct >= 80) return 'green';
-              if (pct >= 60) return 'yellow';
-              if (pct >= 40) return 'orange';
-              return 'red';
-            };
-
-            const overallCoverage = (lines + statements + functions + branches) / 4;
-            const statusEmoji = getCoverageEmoji(overallCoverage);
-
-            const body = `## ${statusEmoji} Test Coverage Report - \`${workspace}\`
-
-            ### Overall Coverage: ${overallCoverage.toFixed(2)}%
-
-            | Metric | Coverage | Status |
-            |--------|----------|--------|
-            | ${getCoverageEmoji(lines)} Lines | **${lines}%** | ${getCoverageColor(lines)} |
-            | ${getCoverageEmoji(statements)} Statements | **${statements}%** | ${getCoverageColor(statements)} |
-            | ${getCoverageEmoji(functions)} Functions | **${functions}%** | ${getCoverageColor(functions)} |
-            | ${getCoverageEmoji(branches)} Branches | **${branches}%** | ${getCoverageColor(branches)} |
-
-            ---
-
-            📊 **[View Detailed Coverage Report](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})**
-
-            <details>
-            <summary>ℹ️ Coverage Thresholds</summary>
-
-            - 🟢 **Excellent** (≥ 80%)
-            - 🟡 **Good** (60-79%)
-            - 🟠 **Fair** (40-59%)
-            - 🔴 **Poor** (< 40%)
-
-            </details>
-            `;
-
-            // Find existing comment
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-
-            const botComment = comments.find(comment =>
-              comment.user.type === 'Bot' &&
-              comment.body.includes(`Test Coverage Report - \`${workspace}\``)
-            );
-
-            // Update or create comment
-            if (botComment) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: botComment.id,
-                body: body
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body: body
-              });
-            }
-
-            // Set status based on coverage threshold
-            if (overallCoverage < 70) {
-              core.setFailed(`Coverage is below 70% for ${workspace}: ${overallCoverage.toFixed(2)}%`);
-            }
 
       - name: Check coverage threshold
         working-directory: ${{ matrix.path }}
@@ -186,20 +94,122 @@ jobs:
           OVERALL=$(awk "BEGIN {printf \"%.2f\", ($LINES + $STATEMENTS + $FUNCTIONS + $BRANCHES) / 4}")
           THRESHOLD=70
 
-          echo "📊 Coverage Summary:"
-          echo "  Lines: $LINES%"
+          echo "Coverage Summary for ${{ matrix.workspace }}:"
+          echo "  Lines:      $LINES%"
           echo "  Statements: $STATEMENTS%"
-          echo "  Functions: $FUNCTIONS%"
-          echo "  Branches: $BRANCHES%"
-          echo "  Overall: $OVERALL%"
+          echo "  Functions:  $FUNCTIONS%"
+          echo "  Branches:   $BRANCHES%"
+          echo "  Overall:    $OVERALL%"
 
-          # Compare using awk
           BELOW_THRESHOLD=$(awk "BEGIN {print ($OVERALL < $THRESHOLD)}")
 
           if [ "$BELOW_THRESHOLD" = "1" ]; then
             echo "::error::Overall coverage is below ${THRESHOLD}% threshold: $OVERALL%"
-            echo "❌ Coverage threshold check failed for ${{ matrix.workspace }}"
+            echo "Coverage threshold check failed for ${{ matrix.workspace }}"
             exit 1
           else
-            echo "✅ Coverage threshold check passed for ${{ matrix.workspace }} (${OVERALL}%)"
+            echo "Coverage threshold check passed for ${{ matrix.workspace }} (${OVERALL}%)"
           fi
+
+      - name: Write coverage summary artifact
+        if: always()
+        working-directory: ${{ matrix.path }}
+        run: |
+          WORKSPACE="${{ matrix.workspace }}"
+          LINES=${{ steps.coverage.outputs.lines }}
+          STATEMENTS=${{ steps.coverage.outputs.statements }}
+          FUNCTIONS=${{ steps.coverage.outputs.functions }}
+          BRANCHES=${{ steps.coverage.outputs.branches }}
+          OVERALL=$(awk "BEGIN {printf \"%.2f\", ($LINES + $STATEMENTS + $FUNCTIONS + $BRANCHES) / 4}")
+
+          {
+            echo "workspace=$WORKSPACE"
+            echo "lines=$LINES"
+            echo "statements=$STATEMENTS"
+            echo "functions=$FUNCTIONS"
+            echo "branches=$BRANCHES"
+            echo "overall=$OVERALL"
+          } > coverage-numbers-${{ matrix.short }}.txt
+
+      - name: Upload coverage numbers
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-numbers-${{ matrix.short }}
+          path: ${{ matrix.path }}/coverage-numbers-${{ matrix.short }}.txt
+          retention-days: 1
+
+  comment:
+    runs-on: ubuntu-latest
+    needs: [test-coverage]
+    if: always()
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Download coverage numbers
+        uses: actions/download-artifact@v4
+        with:
+          pattern: coverage-numbers-*
+          merge-multiple: true
+
+      - name: Build combined coverage comment
+        id: build_comment
+        run: |
+          get_emoji() {
+            pct=$1
+            if awk "BEGIN {exit !($pct >= 80)}"; then echo "🟢"
+            elif awk "BEGIN {exit !($pct >= 60)}"; then echo "🟡"
+            elif awk "BEGIN {exit !($pct >= 40)}"; then echo "🟠"
+            else echo "🔴"
+            fi
+          }
+
+          {
+            echo "## Test Coverage Report"
+            echo ""
+            echo "| Workspace | Lines | Statements | Functions | Branches | Overall |"
+            echo "|-----------|-------|------------|-----------|----------|---------|"
+          } > comment.md
+
+          for f in coverage-numbers-core.txt coverage-numbers-ui.txt; do
+            if [ -f "$f" ]; then
+              # Source key=value pairs into COV_* variables
+              while IFS='=' read -r key val; do
+                export "COV_${key^^}=$val"
+              done < "$f"
+
+              W="$COV_WORKSPACE"
+              L="$COV_LINES"
+              S="$COV_STATEMENTS"
+              FN="$COV_FUNCTIONS"
+              B="$COV_BRANCHES"
+              O="$COV_OVERALL"
+
+              EL=$(get_emoji "$L")
+              ES=$(get_emoji "$S")
+              EF=$(get_emoji "$FN")
+              EB=$(get_emoji "$B")
+              EO=$(get_emoji "$O")
+
+              echo "| \`$W\` | $EL ${L}% | $ES ${S}% | $EF ${FN}% | $EB ${B}% | $EO **${O}%** |" >> comment.md
+            else
+              # matrix leg failed before uploading artifact
+              name="${f#coverage-numbers-}"
+              name="${name%.txt}"
+              echo "| \`@dittolive/ditto-chat-$name\` | — | — | — | — | job failed |" >> comment.md
+            fi
+          done
+
+          {
+            echo ""
+            echo "---"
+            echo ""
+            echo "Threshold: 70% overall. [View full coverage artifacts](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+          } >> comment.md
+
+      - name: Post sticky PR comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: test-coverage
+          path: comment.md


### PR DESCRIPTION
CI cleanup, independent of any feature work.

**OWASP dependency check is no longer PR-blocking.** It was failing PRs on transitive CVEs unrelated to the change. Now:
- Runs weekly (cron) + `workflow_dispatch` instead of on every PR.
- On failure, opens/updates a single tracking issue (`peter-evans/create-issue-from-file`) instead of commenting on PRs.
- Pinned `Dependency-Check_Action` to `1.1.0` (was `@main`); emits `HTML,JSON` only; single CVSS gate.

**One coverage comment instead of comment spam.** The matrix posted a separate hand-rolled comment per workspace. Now a single `comment` job aggregates both workspaces into one sticky comment (`marocchino/sticky-pull-request-comment`), keyed by header so it edits in place.

**Other hygiene:**
- Dropped the duplicate coverage gate (kept the bash threshold check).
- Added `concurrency` (cancel-in-progress) to PR workflows.
- Trimmed `permissions` to the minimum each workflow needs.

`publish-npm.yml` and `android-publish.yml` untouched. Verified with `actionlint` (clean on changed files). Scheduled-run / issue-creation behavior can't be fully exercised pre-merge.